### PR TITLE
Add VCF Tools package  AGR-2247

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /workdir
 
 RUN apt-get update && apt-get -qq install -y apt-utils && apt-get -qq upgrade -y && apt-get -qq dist-upgrade -y
 
-RUN apt-get -qq install -y --no-install-recommends make vim vim-common vim-runtime ssh git wget unzip locales nodejs python3.7 python3-pip maven ansible curl python-pip tabix awscli gcc python3-dev
+RUN apt-get -qq install -y --no-install-recommends make vim vim-common vim-runtime ssh git wget unzip locales nodejs python3.7 python3-pip maven ansible curl python-pip tabix vcftools awscli gcc python3-dev
 
 RUN pip install boto
 RUN pip3 install setuptools wheel


### PR DESCRIPTION
This is required by the File Generator but will likely be needed elsewhere. This package will no longer be needed in the agr_file_generator repo after it is added to the base image with the PR