### PR TITLE
Fixed the AWS CLI 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get -qq install -y apt-utils && apt-get -qq upgrade -y
 RUN apt-get -qq install -y --no-install-recommends make vim vim-common vim-runtime ssh git wget unzip locales nodejs python3.7 python3-pip maven ansible curl tabix vcftools awscli gcc python3-dev jq leiningen
 
 RUN pip3 install boto3 boto
+RUN pip3 install --upgrade awscli
 
 RUN wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 


### PR DESCRIPTION
AWS CLI failed to function, throwing error like ```ImportError: cannot import name 'docevents' from 'botocore.docs.bcdoc'``` when being called (from ansible). This package upgrade fixes the errors.
Correct AWS CLI functionality is required for spot instance launching through ansible.